### PR TITLE
fix: eliminar atributo version obsoleto en docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # PostgreSQL Database
   postgres:


### PR DESCRIPTION
  - Remover version: '3.8' que genera warning en Docker Compose moderno
  - Mantener compatibilidad con Docker Compose v2+
  - Limpiar configuración para desarrollo local